### PR TITLE
fix(env): Use null value over delete keyword

### DIFF
--- a/ENV.js
+++ b/ENV.js
@@ -72,8 +72,8 @@ var ENV = ENV || (function() {
       value.formatElapsed = "";
       value.elapsedClassName = "";
       value.query = "";
-      delete value.elapsed;
-      delete value.waiting;
+      value.elapsed = null;
+      value.waiting = null;
     } else {
       return {
         query: "***",
@@ -157,7 +157,7 @@ var ENV = ENV || (function() {
       if (!row.lastSample || Math.random() < ENV.mutations()) {
         counter = counter + 1;
         if (!keepIdentity) {
-          delete row.lastSample;
+          row.lastSample = null;
         }
         generateRow(row, keepIdentity, counter);
       } else {


### PR DESCRIPTION
![https://i.imgur.com/h6JV76E.png](https://i.imgur.com/h6JV76E.png)

Left: Uses `null`
Right: Uses `delete`

See issue #36
